### PR TITLE
Add navigate output to Animatepicker (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ All the above @Input's() can be used with the directive implementation as well. 
 @Input() closeOnBlur = true; // Close datepicker on blur
 ```
 
+### Outputs
+
+The following output is available for Animatepicker:
+
+```ts
+@Output() navigate: EventEmitter<YearMonth[]>; // Emits year and month of each visible month when navigation changes
+```
+
 ### Composing
 You can add a footer or header to the datepicker by adding a `<footer>` or `<header>` element between the tags.
 

--- a/projects/ngx-animating-datepicker/README.md
+++ b/projects/ngx-animating-datepicker/README.md
@@ -117,6 +117,14 @@ All the above @Input's() can be used with the directive implementation as well. 
 @Input() closeOnBlur = true; // Close datepicker on blur
 ```
 
+### Outputs
+
+The following output is available for Animatepicker:
+
+```ts
+@Output() navigate: EventEmitter<YearMonth[]>; // Emits year and month of each visible month when navigation changes
+```
+
 ### Composing
 You can add a footer to the datepicker by adding a `<footer>` element between the tags.
 

--- a/projects/ngx-animating-datepicker/src/lib/components/animatepicker/animatepicker.component.spec.ts
+++ b/projects/ngx-animating-datepicker/src/lib/components/animatepicker/animatepicker.component.spec.ts
@@ -21,4 +21,14 @@ describe('AnimatepickerComponent', () => {
 	it('should be created', () => {
 		expect(component).toBeTruthy();
 	});
+
+	it('should emit navigate when the visible month changes', () => {
+		const navigateSpy = vi.spyOn(component.navigate, 'emit');
+		component.goToDate(new Date(2024, 0, 1));
+		expect(navigateSpy).toHaveBeenCalledWith([{ year: 2024, month: 0 }]);
+
+		navigateSpy.mockClear();
+		component.goToNextMonth();
+		expect(navigateSpy).toHaveBeenCalledWith([{ year: 2024, month: 1 }]);
+	});
 });

--- a/projects/ngx-animating-datepicker/src/lib/components/animatepicker/animatepicker.component.ts
+++ b/projects/ngx-animating-datepicker/src/lib/components/animatepicker/animatepicker.component.ts
@@ -2,9 +2,11 @@ import {
 	AfterViewInit,
 	Component,
 	ElementRef,
+	EventEmitter,
 	HostBinding,
 	Input,
 	OnInit,
+	Output,
 	ViewChild,
 } from '@angular/core';
 import { YearMonth, Month } from '../../models/datepicker.model';
@@ -30,10 +32,20 @@ export class AnimatepickerComponent extends DatepickerComponent implements OnIni
 	public leftInnerPosition = 0;
 	public transition: string;
 	public translateX: number;
-	public currentYearMonth: object = null;
 	public datepickerPosition: object;
 	public initialised = false;
-	public calendarHeight: number
+	public calendarHeight: number;
+
+	private _currentYearMonth: YearMonth[] = null;
+
+	set currentYearMonth(yearMonths: YearMonth[]) {
+		this._currentYearMonth = yearMonths;
+		this.navigate.emit(yearMonths);
+	}
+
+	get currentYearMonth(): YearMonth[] {
+		return this._currentYearMonth;
+	}
 
 	/* ==============================================
 	 * External Properties
@@ -57,6 +69,13 @@ export class AnimatepickerComponent extends DatepickerComponent implements OnIni
 	get numberOfMonths(): Number[] {
 		return this._numberOfMonths;
 	}
+
+	/* ==============================================
+	 * Outputs
+	 * ============================================== */
+
+	@Output()
+	navigate = new EventEmitter<YearMonth[]>();
 
 	/* ==============================================
 	 * Bindings and Children

--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -22,10 +22,13 @@
                         [theme]="animateInputsForm.value.theme"
                         [options]="animateOptions"
                         [(selectedDates)]="selectedDatesAnimate"
+                        (navigate)="yearMonths = $event"
                         #demoDatepicker>
                     </aa-animatepicker>
                 </div>
                 <div class="demo__output-example">
+                    <h4>Visible months:</h4>
+                    <pre>{{ yearMonths | json }}</pre>
                     <h4>Output:</h4>
                     <ul class="demo__selected-dates-list">
                         <li *ngFor="let date of selectedDatesAnimate; let i = index" class="demo__selected-dates-item">

--- a/src/app/demo/demo.component.ts
+++ b/src/app/demo/demo.component.ts
@@ -28,6 +28,7 @@ export class DemoComponent implements OnInit {
 	public selectedMinDate;
 	public selectedMaxDate;
 	public numberOfMonths;
+	public yearMonths;
 
 	@ViewChild('demoDatepicker', { static: true }) demoDatepicker: AnimatepickerComponent;
 	public directiveForm: FormGroup;


### PR DESCRIPTION
## Summary
- Adds `(navigate)` output to `aa-animatepicker` that emits `YearMonth[]` whenever the visible month range changes (prev/next arrows, month/year picker, programmatic navigation)
- Updates the demo to show visible months in real time
- Documents the new output in both README files
- Adds a unit test for navigation emissions

Re-implements the idea from #19 on top of the Angular 21 codebase. Closes #17.

## Test plan
- [x] `npm test` passes (library + app)
- [ ] Open demo, click prev/next month arrows — "Visible months" JSON updates
- [ ] Change `numberOfMonths` — emitted array length matches visible months
- [ ] Pick a month from the sub-navigation — `(navigate)` reflects the new range


Made with [Cursor](https://cursor.com)