### PR TITLE
Supply-chain cooldowns and npm publish workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       angular:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test
+
+      - name: Verify tag matches library version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          VERSION=$(node -p "require('./projects/ngx-animating-datepicker/package.json').version")
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "Tag v$TAG does not match library version $VERSION"
+            exit 1
+          fi
+
+      - run: npm run lib:build
+
+      - run: npm run copy:readme
+
+      - name: Publish to npm
+        working-directory: dist/ngx-animating-datepicker
+        run: npm publish --access public

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Delay installing newly published versions (supply-chain defense).
+# Align with Dependabot cooldown in .github/dependabot.yml.
+min-release-age=7d

--- a/README.md
+++ b/README.md
@@ -180,6 +180,54 @@ Implement your custom component into the datepicker by using the `ng-content` lo
 npm install
 npm start              # demo app
 npm run lib:build      # build library
-npm run lib:publish    # build + pack for npm publish
+npm run lib:publish    # build + pack (dry run before publish)
 npm test               # run unit tests (non-watch)
 ```
+
+### Dependency safety
+
+This repo uses a **7-day release cooldown** to reduce npm supply-chain risk (Shai-Hulud-style attacks):
+
+- `.npmrc` — `min-release-age=7d` blocks installing brand-new package versions
+- `.github/dependabot.yml` — matching Dependabot cooldown (security updates are not delayed)
+
+Requires **npm 11.10+** (`packageManager` in `package.json`; enable with `corepack enable`).
+
+### Publishing to npm
+
+**Recommended setup:** [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers/) (OIDC via GitHub Actions). No long-lived `NPM_TOKEN` in secrets; publishes get provenance attestations automatically.
+
+#### One-time npm setup
+
+1. Sign in at [npmjs.com](https://www.npmjs.com/) as the package owner (`koenzz`).
+2. Open [ngx-animating-datepicker → Settings → Trusted Publisher](https://www.npmjs.com/package/ngx-animating-datepicker/access).
+3. Add a **GitHub Actions** trusted publisher:
+   - **Organization or user:** `koenz`
+   - **Repository:** `angular-datepicker`
+   - **Workflow filename:** `publish.yml`
+   - **Environment:** leave empty (unless you add a GitHub Environment later)
+
+#### Release a version
+
+1. Bump `version` in `projects/ngx-animating-datepicker/package.json`.
+2. Commit, merge to `develop`, then tag:
+
+```bash
+git tag v2.0.0
+git push origin v2.0.0
+```
+
+3. The [Publish to npm](.github/workflows/publish.yml) workflow runs tests, builds the library, and publishes from `dist/ngx-animating-datepicker`.
+
+The git tag must match the library version exactly (`v2.0.0` → `"version": "2.0.0"`).
+
+#### Manual publish (fallback)
+
+```bash
+npm run lib:build
+npm run copy:readme
+cd dist/ngx-animating-datepicker
+npm publish --access public
+```
+
+Use a granular npm access token with **Publish** scope only, or `npm login` with 2FA. Prefer Trusted Publishers for CI.

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "lib:build": "ng build ngx-animating-datepicker",
     "lib:pack": "cd dist/ngx-animating-datepicker && npm pack",
     "lib:publish": "npm run lib:build && npm run copy:readme && npm run lib:pack",
-    "copy:readme": "cp -av README.md dist/ngx-animating-datepicker",
+    "copy:readme": "cp -av projects/ngx-animating-datepicker/README.md dist/ngx-animating-datepicker/README.md",
     "test": "ng test ngx-animating-datepicker --watch=false && ng test ngx-animating-datepicker-app --watch=false"
   },
   "private": true,
-  "packageManager": "npm@10.9.2",
+  "packageManager": "npm@11.16.0",
   "dependencies": {
     "@angular/animations": "^21.2.0",
     "@angular/common": "^21.2.0",

--- a/projects/ngx-animating-datepicker/package.json
+++ b/projects/ngx-animating-datepicker/package.json
@@ -11,9 +11,22 @@
     "ngx",
     "angular 21"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/koenz/angular-datepicker.git",
+    "directory": "projects/ngx-animating-datepicker"
+  },
+  "homepage": "https://github.com/koenz/angular-datepicker#readme",
+  "bugs": {
+    "url": "https://github.com/koenz/angular-datepicker/issues"
+  },
   "peerDependencies": {
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `.npmrc` with `min-release-age=7d` and matching Dependabot cooldown (7/14/3 days by semver)
- Bumps `packageManager` to npm 11.16 and enables Corepack in CI
- Adds `publish.yml` workflow: tag-triggered publish via npm Trusted Publishers (OIDC)
- Adds library `repository` / `publishConfig.provenance` metadata for npm provenance
- Documents one-time trusted publisher setup and release steps in README

## Test plan
- [x] `npm test` passes locally
- [x] `npm run lib:publish` produces tarball with README + metadata
- [ ] Configure npm Trusted Publisher for `publish.yml` (one-time, before first CI publish)
- [ ] After merge: `git tag v2.0.0 && git push origin v2.0.0`


Made with [Cursor](https://cursor.com)